### PR TITLE
Install tries to insert postBuildEventText instead of appending it.

### DIFF
--- a/tools/CreateNewNuGetPackageFromProjectAfterEachBuild NuGet Package/CreateNewNuGetPackageFromProjectAfterEachBuild.nuspec
+++ b/tools/CreateNewNuGetPackageFromProjectAfterEachBuild NuGet Package/CreateNewNuGetPackageFromProjectAfterEachBuild.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.8">
     <id>CreateNewNuGetPackageFromProjectAfterEachBuild</id>
-    <version>1.8.13</version>
+    <version>1.8.14</version>
     <title>Create New NuGet Package From Project After Each Build</title>
     <authors>Daniel Schroeder,iQmetrix</authors>
     <owners>Daniel Schroeder,iQmetrix</owners>

--- a/tools/CreateNewNuGetPackageFromProjectAfterEachBuild NuGet Package/tools/Install.ps1
+++ b/tools/CreateNewNuGetPackageFromProjectAfterEachBuild NuGet Package/tools/Install.ps1
@@ -42,8 +42,18 @@ if ($postBuildEventText.Contains($postBuildEventCode))
 	return
 }
 
-# Add the Post-Build Event Code to the project (prepend a couple newlines in case there is existing Post Build Event text).
-$postBuildEventText += "`n`r`n`r$postBuildEventCode"
+#Marker created in Uninstall.ps1
+$postBuildEventCodeMarker = @'
+REM CreateNewNuGetPackageFromProjectAfterEachBuild Update Block
+'@
+
+if ($postBuildEventText.Contains($postBuildEventCodeMarker)) {
+    $postBuildEventText = $postBuildEventText.Replace($postBuildEventCodeMarker, "`n`r`n`r$postBuildEventCode")
+} else {
+    # Add the Post-Build Event Code to the project (prepend a couple newlines in case there is existing Post Build Event text).
+    $postBuildEventText += "`n`r`n`r$postBuildEventCode"
+}
+
 $project.Properties.Item("PostBuildEvent").Value = $postBuildEventText.Trim()
 
 # Change the build action of the NuGet.exe file from Content to None.

--- a/tools/CreateNewNuGetPackageFromProjectAfterEachBuild NuGet Package/tools/Uninstall.ps1
+++ b/tools/CreateNewNuGetPackageFromProjectAfterEachBuild NuGet Package/tools/Uninstall.ps1
@@ -2,21 +2,23 @@
 
 # Get the current Post-Build Event text.
 $postBuildEventText = $project.Properties.Item("PostBuildEvent").Value
-
+$postBuildEventCodeMarker = @'
+REM CreateNewNuGetPackageFromProjectAfterEachBuild Update Block
+'@
 ###### Start of code to remove older versions of post build event text.
 $oldPostBuildEventCode = @'
 REM Create a NuGet package for this project and place the .nupkg file in the project's output directory.
 ECHO Building NuGet package in Post-Build event...
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '$(ProjectDir)PostBuildScripts\BuildNewPackage-RanAutomatically.ps1' -ProjectFilePath '$(ProjectPath)' -OutputDirectory '$(TargetDir)' -Configuration '$(ConfigurationName)' -Platform '$(PlatformName)'"
 '@
-$postBuildEventText = $postBuildEventText.Replace($oldPostBuildEventCode, [string]::Empty)
+$postBuildEventText = $postBuildEventText.Replace($oldPostBuildEventCode, $postBuildEventCodeMarker)
 
 $oldPostBuildEventCode = @'
 REM Create a NuGet package for this project and place the .nupkg file in the project's output directory.
 ECHO Building NuGet package in Post-Build event...
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '$(ProjectDir)PostBuildScripts\BuildNewPackage-RanAutomatically.ps1' -ProjectFilePath '$(ProjectPath)' -OutputDirectory '$(TargetDir)' -Configuration='$(ConfigurationName)' -Platform='$(PlatformName)'"
 '@
-$postBuildEventText = $postBuildEventText.Replace($oldPostBuildEventCode, [string]::Empty)
+$postBuildEventText = $postBuildEventText.Replace($oldPostBuildEventCode, $postBuildEventCodeMarker)
 
 $oldPostBuildEventCode = @'
 REM Create a NuGet package for this project and place the .nupkg file in the project's output directory.
@@ -24,7 +26,7 @@ REM If you see this in Visual Studio's Error List window, check the Output windo
 ECHO Building NuGet package in Post-Build event...
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '$(ProjectDir)PostBuildScripts\BuildNewPackage-RanAutomatically.ps1' -ProjectFilePath '$(ProjectPath)' -OutputDirectory '$(TargetDir)' -Configuration '$(ConfigurationName)' -Platform '$(PlatformName)'"
 '@
-$postBuildEventText = $postBuildEventText.Replace($oldPostBuildEventCode, [string]::Empty)
+$postBuildEventText = $postBuildEventText.Replace($oldPostBuildEventCode, $postBuildEventCodeMarker)
 ###### End of code to remove older versions of post build event text.
 
 # Define the Post-Build Event Code to remove.
@@ -36,6 +38,6 @@ PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '$(ProjectDir)_CreateN
 '@
 
 # Remove the Post-Build Event Code to the project and save it.
-$postBuildEventText = $postBuildEventText.Replace($postBuildEventCode, [string]::Empty)
+$postBuildEventText = $postBuildEventText.Replace($postBuildEventCode, $postBuildEventCodeMarker)
 $project.Properties.Item("PostBuildEvent").Value = $postBuildEventText.Trim()
 $project.Save()


### PR DESCRIPTION
This is my attempt to solve the problem. Put a mark on Uninstall and use it on Install, the drawback is that the marker stays there after the package is removed for good.